### PR TITLE
Fix return output on no allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 venv/
 .ipynb_checkpoints
 .pytest_cache
+var/

--- a/domino_cost/cost_dashboard.py
+++ b/domino_cost/cost_dashboard.py
@@ -329,10 +329,12 @@ def update(time_span, billing_tag, project, user):
     allocations = get_aggregated_allocations(time_span, base_url=cost.cost_url, headers=auth_header)
 
     if not allocations:
+        logger.info("No allocations found for the given time span")
         return (
             [],
             [],
             [],
+            "No data",
             "No data",
             "No data",
             "No data",

--- a/domino_cost/requests_helpers.py
+++ b/domino_cost/requests_helpers.py
@@ -42,7 +42,7 @@ def get_cloud_cost_sum(selection: str, base_url: str, headers: dict) -> float:
         config.cloud_cost_available = False
         logger.warning("could not acquire cloud cost - not configured or no data to retrieve")
         logger.warning("setting cloud cost availability: %s", config.cloud_cost_available)
-        logger.debug('exception received when trying to obtain cloud costs: %s', e)
+        logger.debug("exception received when trying to obtain cloud costs: %s", e)
 
     config.default_is_updated = True
     return cloud_cost_sum

--- a/domino_cost/requests_helpers.py
+++ b/domino_cost/requests_helpers.py
@@ -40,8 +40,9 @@ def get_cloud_cost_sum(selection: str, base_url: str, headers: dict) -> float:
         logger.info("setting cloud cost availability: %s", config.cloud_cost_available)
     except Exception as e:  # handle for users without cloud cost, or no data from cloudCost
         config.cloud_cost_available = False
+        logger.warning("could not acquire cloud cost - not configured or no data to retrieve")
         logger.warning("setting cloud cost availability: %s", config.cloud_cost_available)
-        logger.error("acquiring cloud cost failed: %s", e)
+        logger.debug('exception received when trying to obtain cloud costs: %s', e)
 
     config.default_is_updated = True
     return cloud_cost_sum


### PR DESCRIPTION
### What issue does this pull request solve?

When no allocations were found, the return structure was missing a "No Data" value for one of the cards

### What is the solution?

Add a new "No Data" in the return for no allocations

Apart from this, modified a logging line from error to warning, since not having cloud costs enabled is completely fine and expected. So it should be just a warning rather than an error

### Where should reviewer start?

_placeholder_

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
