### PR TITLE
Modify empty return values for charts and figures

### DIFF
--- a/domino_cost/cost_dashboard.py
+++ b/domino_cost/cost_dashboard.py
@@ -337,12 +337,12 @@ def update(time_span, billing_tag, project, user):
             "No data",
             "No data",
             "No data",
-            "No data",
             {},
-            None,
-            None,
-            None,
-            None,
+            {},
+            {},
+            {},
+            {},
+            {},
             None,
         )
 


### PR DESCRIPTION
### What issue does this pull request solve?

10/22/2024 1:49 PM :     raise SchemaLengthValidationError(value, full_schema, path, expected_len)
10/22/2024 1:49 PM : dash._grouping.SchemaLengthValidationError: Schema: [<Output `billing_select.options`>, <Output `project_select.options`>, <Output `user_select.options`>, <Output `totalcard.children`>, <Output `cloudcard.children`>, <Output `computecard.children`>, <Output `storagecard.children`>, <Output `cumulative-daily-costs.figure`>, <Output `user_chart.figure`>, <Output `project_chart.figure`>, <Output `org_chart.figure`>, <Output `tag_chart.figure`>, <Output `workload-cost-table-container.children`>]
10/22/2024 1:49 PM : Path: ()
10/22/2024 1:49 PM : Expected length: 13
10/22/2024 1:49 PM : Received value of length 12:
10/22/2024 1:49 PM :     [[], [], [], 'No data', 'No data', 'No data', {}, None, None, None, None, None]

### What is the solution?

Update the return values for no allocations charts and figures from None to {}.

### Where should reviewer start?

update function in the domino-cost/cost_dashboard.py

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
https://dominodatalab.slack.com/archives/C064ZP999FW/p1729536218150729