### PR TITLE
Fix return structure on no allocations

### DIFF
--- a/domino_cost/cost_dashboard.py
+++ b/domino_cost/cost_dashboard.py
@@ -325,7 +325,6 @@ output_list = [
     ],
 )
 def update(time_span, billing_tag, project, user):
-    cloud_cost_sum = get_cloud_cost_sum(time_span, base_url=cost.cost_url, headers=auth_header)
     allocations = get_aggregated_allocations(time_span, base_url=cost.cost_url, headers=auth_header)
 
     if not allocations:
@@ -339,13 +338,14 @@ def update(time_span, billing_tag, project, user):
             "No data",
             "No data",
             {},
-            None,
-            None,
-            None,
-            None,
-            None,
+            {},
+            {},
+            {},
+            {},
+            {},
         )
 
+    cloud_cost_sum = get_cloud_cost_sum(time_span, base_url=cost.cost_url, headers=auth_header)
     cost_table = get_execution_cost_table(allocations)
     distributed_cost_table = get_distributed_execution_cost(cost_table, cloud_cost_sum)
 


### PR DESCRIPTION
### What issue does this pull request solve?

When no allocations are found, the update callback is returning `None` as a structure for some of the chart figures. This makes Dash break and enter an infinite loop

### What is the solution?

- Return an empty dictionary `{}` for the chart figures
- Also, moved obtaining the method to obtain the cloud cost sum after the allocations check is done (since it doesn't make sense to obtain the cloud cost if no allocations were found)

### Where should reviewer start?

_placeholder_

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)
