### PR TITLE
DOM-63124 feat(cost_dashboard): Use the summary endpoint

### DIFF
--- a/domino_cost/cost.py
+++ b/domino_cost/cost.py
@@ -325,11 +325,11 @@ def get_execution_cost_table(aggregated_allocations: List) -> list[dict]:
             logger.warning(e)
             continue
 
-        cpu_cost = costData["cpuCost"] + costData["cpuCostAdjustment"]
-        gpu_cost = costData["gpuCost"] + costData["gpuCostAdjustment"]
+        cpu_cost = costData["cpuCost"] + costData.get("cpuCostAdjustment", 0)
+        gpu_cost = costData["gpuCost"] + costData.get("gpuCostAdjustment", 0)
         compute_cost = cpu_cost + gpu_cost
 
-        ram_cost = costData["ramCost"] + costData["ramCostAdjustment"]
+        ram_cost = costData["ramCost"] + costData.get("ramCostAdjustment", 0)
 
         alloc_total_cost = costData["totalCost"]
 

--- a/domino_cost/requests_helpers.py
+++ b/domino_cost/requests_helpers.py
@@ -49,7 +49,8 @@ def get_cloud_cost_sum(selection: str, base_url: str, headers: dict) -> float:
 
 
 def get_aggregated_allocations(selection: str, base_url: str, headers: dict) -> List:
-    allocations_url = f"{base_url}/allocation"
+    allocations_url = f"{base_url}/allocation/summary"
+    #allocations_url = f"{base_url}/allocation"
 
     params = {
         "window": selection,


### PR DESCRIPTION
### Link to JIRA

[DOM-63124](https://dominodatalab.atlassian.net/browse/DOM-63124)

### What issue does this pull request solve?

The app timeouts when running in clusters with big output/usage.

### What is the solution?

Use the new summary endpoint for domino-cost.
As in the new summary endpoint the adjustment fields are included in the total and not present in the response, adjust the calculation accordingly to default to 0.

### Where should reviewer start?

By looking at https://github.com/cerebrotech/domino/pull/43940

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [ ] Has the JIRA ticket(s) been linked above?

### References (optional)

- https://github.com/cerebrotech/domino/pull/43940