### PR TITLE
Cost histogram label trimming was disordering the labels

### DIFF
--- a/domino_cost/cost.py
+++ b/domino_cost/cost.py
@@ -267,7 +267,7 @@ def get_cost_cards(cost_table: DataFrame) -> tuple[str]:
 
 
 def build_histogram(cost_table: DataFrame, bin_by: str):
-    top = clean_df(cost_table, bin_by).groupby(bin_by)[CostAggregatedLabels.TOTAL_COST.value].sum().grouped.nlargest(10)
+    top = clean_df(cost_table, bin_by).groupby(bin_by)[CostAggregatedLabels.TOTAL_COST.value].sum().nlargest(10)
     top_df = top.reset_index()
     top_df.columns = [bin_by, CostAggregatedLabels.TOTAL_COST.value]
     topIndex = top.index

--- a/domino_cost/cost.py
+++ b/domino_cost/cost.py
@@ -267,8 +267,7 @@ def get_cost_cards(cost_table: DataFrame) -> tuple[str]:
 
 
 def build_histogram(cost_table: DataFrame, bin_by: str):
-    grouped = clean_df(cost_table, bin_by).groupby(bin_by)[CostAggregatedLabels.TOTAL_COST.value].sum()
-    top = grouped.nlargest(10)
+    top = clean_df(cost_table, bin_by).groupby(bin_by)[CostAggregatedLabels.TOTAL_COST.value].sum().grouped.nlargest(10)
     top_df = top.reset_index()
     top_df.columns = [bin_by, CostAggregatedLabels.TOTAL_COST.value]
     topIndex = top.index


### PR DESCRIPTION
### Link to JIRA
https://dominodatalab.atlassian.net/browse/DOM-64921

### What issue does this pull request solve?
Information displayed on the top histograms is not consistent. Because the trimming of the labels was mixing them/

### What is the solution?
Pre-truncate the labels in the correct order and then assign them in the chart.

### Where should reviewer start?

_placeholder_

### Pull Request Reminders

- [ ] Has relevant documentation been updated?
- [X] Has the JIRA ticket(s) been linked above?

### References (optional)
